### PR TITLE
Remove provider definitions from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "confluent-kafka-cluster" {
   ccloud_exporter_image_version     = "latest"
   metric_exporters_namespace        = "sre"
   create_grafana_dashboards         = true
+  grafana_datasource                = "Default Datasource"
   topics = {
     "topic-1" = {
       replication_factor = 3
@@ -62,7 +63,10 @@ The module outputs a map of service account credentials, keyed by the names prov
 
 ## Requirements
 
-Terraform >= 1.0.0
+- Terraform >= 1.0.0
+- Mongey/confluentcloud >= 0.0.12
+- Mongey/kafka >= 0.2.11
+- grafana/grafana >= 1.14.0
 
 ## Inputs
 
@@ -79,10 +83,9 @@ Terraform >= 1.0.0
 | service_provider                                                                                                                                                                                                                        | Confluent cloud service provider. AWS, GCP, Azure                                                            | string | GCP     |          |
 | topics                                                                                                                                                                                                                                  | Kafka topic definitions.                                                                                     |
 | Object map keyed by topic name with topic configuration values as well as reader and writer ACL lists. Values provided to the ACL lists will become service accounts with { key, secret } objects output by service_account_credentials | list(object)                                                                                                 |        | x       |
-| confluent_cloud_username                                                                                                                                                                                                                | Confluent cloud username. Provide via TF_VAR_confluent_cloud_username                                        | string |         |    x     |
-| confluent_cloud_password                                                                                                                                                                                                                | Confluent cloud password. Provide via TF_VAR_confluent_cloud_password                                        | string |         |    x     |
 | enable_metric_exporters                                                                                                                                                                                                                 | Whether to deploy metrics exporters                                                                          | bool   |         |  false   |
 | metric_exporters_namespace                                                                                                                                                                                                              | K8S Namespace in which to deploy metrics exporters                                                           | string |         |   sre    |
 | kafka_lag_exporter_image_version                                                                                                                                                                                                        | Kafka lag exporter image version                                                                             | string |         |  latest  |
 | ccloud_exporter_image_version                                                                                                                                                                                                           | CCloud exporter image version                                                                                | string |         |  latest  |
 | create_grafana_dashboards                                                                                                                                                                                                               | Whether to create Grafana dashboards                                                                         | bool   |         |  false   |
+| grafana_datasource                                                                                                                                                                                                                      | Grafana datasource to use in dashboards                                                                      | string |         |   null   |

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     confluentcloud = {
       source  = "Mongey/confluentcloud"
-      version = "0.0.12"
+      version = ">= 0.0.12"
     }
     kafka = {
       source  = "Mongey/kafka"
-      version = "0.2.11"
+      version = ">= 0.2.11"
     }
     grafana = {
       source  = "grafana/grafana"
@@ -38,20 +38,6 @@ locals {
     [for v in local.readers_map : v.user],
     [for v in local.writers_map : v.user]
   )
-}
-
-provider "confluentcloud" {
-  username = var.confluent_cloud_username
-  password = var.confluent_cloud_password
-}
-
-provider "kafka" {
-  bootstrap_servers = local.bootstrap_servers
-  tls_enabled       = true
-  sasl_username     = confluentcloud_api_key.admin_api_key.key
-  sasl_password     = confluentcloud_api_key.admin_api_key.secret
-  sasl_mechanism    = "plain"
-  timeout           = 10
 }
 
 resource "confluentcloud_environment" "environment" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,9 @@ output "kafka_url" {
   description = "URL to connect your Kafka clients to"
   value       = local.bootstrap_servers
 }
+
+output "admin_api_key" {
+  description = "Admin user api key and secret"
+  value       = confluentcloud_api_key.admin_api_key
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -66,18 +66,6 @@ variable "topics" {
   )
 }
 
-variable "confluent_cloud_username" {
-  description = "Confluent cloud username"
-  type        = string
-  sensitive   = true
-}
-
-variable "confluent_cloud_password" {
-  description = "Confluent cloud password"
-  type        = string
-  sensitive   = true
-}
-
 variable "enable_metric_exporters" {
   description = "Whether to deploy kafka-lag-exporter and ccloud-exporter in a kubernetes cluster"
   type        = bool
@@ -111,4 +99,5 @@ variable "create_grafana_dashboards" {
 variable "grafana_datasource" {
   description = "Name of Grafana data source where Kafka metrics are stored"
   type        = string
+  default     = null
 }


### PR DESCRIPTION
Provider definitions should live in the root module and configured there.
This PR removes provider definitions and outputs values required by the kafka provider from confluent cloud resources