### PR TITLE
Fix service account names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "confluentcloud_api_key" "admin_api_key" {
 
 resource "confluentcloud_service_account" "service_accounts" {
   for_each    = toset(local.service_accounts)
-  name        = each.value
+  name        = "${local.lc_name}-${each.value}"
   description = "${each.value} service account"
 }
 
@@ -72,7 +72,7 @@ resource "confluentcloud_api_key" "ccloud_exporter_api_key" {
 resource "confluentcloud_service_account" "kafka_lag_exporter" {
   count = var.enable_metric_exporters ? 1 : 0
 
-  name        = "kafka-lag-exporter"
+  name        = "${local.lc_name}-kafka-lag-exporter"
   description = "Kafka lag exporter service account"
 }
 
@@ -102,6 +102,7 @@ resource "confluentcloud_kafka_cluster" "cluster" {
   region           = var.gcp_region
   availability     = var.availability
   environment_id   = confluentcloud_environment.environment.id
+  cku              = var.cku
   deployment = {
     sku = var.cluster_tier
   }

--- a/templates/kafka-lag-exporter.json
+++ b/templates/kafka-lag-exporter.json
@@ -1023,6 +1023,6 @@
   },
   "timezone": "",
   "title": "Kafka Lag Exporter",
-  "uid": "8LW1Yd8ik",
-  "version": 14
+  "uid": null,
+  "version": 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "cluster_tier" {
   default     = "BASIC"
 }
 
+variable "cku" {
+  description = "Number of CKUs"
+  type        = number
+  default     = null
+}
+
 variable "service_provider" {
   description = "Confluent cloud service provider. AWS, GCP, Azure"
   type        = string


### PR DESCRIPTION
Service account names conflict across environments. Adding the cluster name as a prefix will help avoid that.
Dedicated clusters require a CKU config.
Lag dashboard had a UID hardcoded.