### PR TITLE
Add missing ACL and remove dashboard variables

### DIFF
--- a/grafana-dashboards.tf
+++ b/grafana-dashboards.tf
@@ -10,6 +10,7 @@ resource "grafana_dashboard" "ccloud_exporter" {
     "${path.module}/templates/ccloud-exporter.json",
     {
       datasource = var.grafana_datasource
+      clusterID  = confluentcloud_kafka_cluster.cluster.id
     }
   )
 }
@@ -20,7 +21,8 @@ resource "grafana_dashboard" "kafka_lag_exporter" {
   config_json = templatefile(
     "${path.module}/templates/kafka-lag-exporter.json",
     {
-      datasource = var.grafana_datasource
+      datasource  = var.grafana_datasource
+      clusterName = local.lc_name
     }
   )
 }

--- a/kafka-lag-exporter.tf
+++ b/kafka-lag-exporter.tf
@@ -33,6 +33,7 @@ resource "kubernetes_secret" "lag_exporter_config" {
         password         = confluentcloud_api_key.kafka_lag_exporter_api_key[0].secret
         namespace        = var.metric_exporters_namespace
         bootstrapBrokers = local.bootstrap_servers[0]
+        clusterName      = local.lc_name
     })
     "logback.xml" = file("${path.module}/templates/logback.xml")
   }

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ resource "confluentcloud_api_key" "kafka_lag_exporter_api_key" {
   user_id        = confluentcloud_service_account.kafka_lag_exporter[0].id
 }
 
-resource "kafka_acl" "kafka_lag_exporter" {
+resource "kafka_acl" "kafka_lag_exporter_read_topic" {
   count = var.enable_metric_exporters ? 1 : 0
 
   resource_name       = "*"
@@ -93,6 +93,28 @@ resource "kafka_acl" "kafka_lag_exporter" {
   acl_principal       = "User:${confluentcloud_service_account.kafka_lag_exporter[0].id}"
   acl_host            = "*"
   acl_operation       = "Read"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "kafka_lag_exporter_describe_topic" {
+  count = var.enable_metric_exporters ? 1 : 0
+
+  resource_name       = "*"
+  resource_type       = "Topic"
+  acl_principal       = "User:${confluentcloud_service_account.kafka_lag_exporter[0].id}"
+  acl_host            = "*"
+  acl_operation       = "Describe"
+  acl_permission_type = "Allow"
+}
+
+resource "kafka_acl" "kafka_lag_exporter_describe_consumer_group" {
+  count = var.enable_metric_exporters ? 1 : 0
+
+  resource_name       = "*"
+  resource_type       = "Group"
+  acl_principal       = "User:${confluentcloud_service_account.kafka_lag_exporter[0].id}"
+  acl_host            = "*"
+  acl_operation       = "Describe"
   acl_permission_type = "Allow"
 }
 

--- a/templates/application.conf
+++ b/templates/application.conf
@@ -6,7 +6,7 @@ kafka-lag-exporter {
     kafka-client-timeout = 10 seconds
     clusters = [
       {
-        name = "default"
+        name = "${clusterName}"
         bootstrap-brokers = "${bootstrapBrokers}"
         consumer-properties = {
           request.timeout.ms = "200000"

--- a/templates/ccloud-exporter.json
+++ b/templates/ccloud-exporter.json
@@ -115,7 +115,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "sum(ccloud_metric_partition_count{kafka_id=~\"$cluster\"})",
+          "expr": "sum(ccloud_metric_partition_count{kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{cluster}}",
@@ -183,7 +183,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "rate(ccloud_metric_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(ccloud_metric_received_bytes{topic=~\"$topic\", kafka_id=\"${clusterID}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{cluster}}",
           "refId": "A"
@@ -250,7 +250,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "rate(ccloud_metric_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(ccloud_metric_sent_bytes{topic=~\"$topic\", kafka_id=\"${clusterID}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{cluster}}",
           "refId": "A"
@@ -317,7 +317,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "sum(rate(ccloud_metric_request_count{type=~\".*\", kafka_id=~\"$cluster\"}[$__rate_interval]))",
+          "expr": "sum(rate(ccloud_metric_request_count{type=~\".*\", kafka_id=\"${clusterID}\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{cluster}}",
           "refId": "A"
@@ -384,7 +384,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "sum(ccloud_metric_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})/3",
+          "expr": "sum(ccloud_metric_retained_bytes{topic=~\"$topic\", kafka_id=\"${clusterID}\"})/3",
           "interval": "",
           "legendFormat": "{{cluster}}",
           "refId": "A"
@@ -452,7 +452,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "abs(delta(ccloud_metric_partition_count{kafka_id=~\"$cluster\"}[5m]))",
+          "expr": "abs(delta(ccloud_metric_partition_count{kafka_id=\"${clusterID}\"}[5m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{cluster}}",
@@ -521,7 +521,7 @@
       "pluginVersion": "7.4.1",
       "targets": [
         {
-          "expr": "avg(ccloud_metric_active_connection_count{kafka_id=~\"$cluster\"})",
+          "expr": "avg(ccloud_metric_active_connection_count{kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{cluster}}",
@@ -668,7 +668,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (kafka_id, topic) (ccloud_metric_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
+          "expr": "sum by (kafka_id, topic) (ccloud_metric_retained_bytes{topic=~\"$topic\", kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kafka_id}}-{{topic}}",
@@ -767,7 +767,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (topic, kafka_id) (ccloud_metric_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
+          "expr": "sum by (topic, kafka_id) (ccloud_metric_received_bytes{topic=~\"$topic\", kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{topic}} - {{kafka_id}}",
@@ -868,7 +868,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (topic, kafka_id) (ccloud_metric_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
+          "expr": "sum by (topic, kafka_id) (ccloud_metric_sent_bytes{topic=~\"$topic\", kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{topic}} - {{kafka_id}}",
@@ -966,7 +966,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (topic, kafka_id) (ccloud_metric_received_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
+          "expr": "sum by (topic, kafka_id) (ccloud_metric_received_records{topic=~\"$topic\", kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{topic}} - {{kafka_id}}",
@@ -1065,7 +1065,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (topic, kafka_id) (ccloud_metric_sent_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
+          "expr": "sum by (topic, kafka_id) (ccloud_metric_sent_records{topic=~\"$topic\", kafka_id=\"${clusterID}\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{topic}} - {{kafka_id}}",
@@ -1168,7 +1168,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccloud_metric_request_count{kafka_id=~\"$cluster\"}",
+          "expr": "ccloud_metric_request_count{kafka_id=\"${clusterID}\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kafka_id}}-{{type}}",
@@ -1273,7 +1273,7 @@
           "pluginVersion": "7.4.1",
           "targets": [
             {
-              "expr": "ccloud_metric_connector_dead_letter_queue_records{connector_kafka_id=~\"$cluster\"}",
+              "expr": "ccloud_metric_connector_dead_letter_queue_records{connector_kafka_id=\"${clusterID}\"}",
               "interval": "",
               "legendFormat": "{{connector_kafka_id}} -- {{connector_id}}",
               "queryType": "randomWalk",
@@ -1326,7 +1326,7 @@
           "pluginVersion": "7.4.1",
           "targets": [
             {
-              "expr": "count(ccloud_metric_connector_dead_letter_queue_records{connector_kafka_id=~\"$cluster\"})",
+              "expr": "count(ccloud_metric_connector_dead_letter_queue_records{connector_kafka_id=\"${clusterID}\"})",
               "interval": "",
               "legendFormat": "",
               "queryType": "randomWalk",
@@ -1386,7 +1386,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "ccloud_metric_connector_sent_records{connector_kafka_id=~\"$cluster\"}",
+              "expr": "ccloud_metric_connector_sent_records{connector_kafka_id=\"${clusterID}\"}",
               "interval": "",
               "legendFormat": "{{connector_kafka_id}} -- {{connector_id}}",
               "queryType": "randomWalk",
@@ -1482,7 +1482,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "ccloud_metric_connector_received_bytes{connector_kafka_id=~\"$cluster\"}",
+              "expr": "ccloud_metric_connector_received_bytes{connector_kafka_id=\"${clusterID}\"}",
               "interval": "",
               "legendFormat": "{{connector_kafka_id}} -- {{connector_id}}",
               "queryType": "randomWalk",
@@ -1578,7 +1578,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "ccloud_metric_connector_sent_bytes{connector_kafka_id=~\"$cluster\"}",
+              "expr": "ccloud_metric_connector_sent_bytes{connector_kafka_id=\"${clusterID}\"}",
               "interval": "",
               "legendFormat": "{{connector_kafka_id}} -- {{connector_id}}",
               "queryType": "randomWalk",
@@ -1674,7 +1674,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "ccloud_metric_connector_received_records{connector_kafka_id=~\"$cluster\"}",
+              "expr": "ccloud_metric_connector_received_records{connector_kafka_id=\"${clusterID}\"}",
               "interval": "",
               "legendFormat": "{{connector_kafka_id}} -- {{connector_id}}",
               "queryType": "randomWalk",
@@ -2143,30 +2143,6 @@
   "tags": [],
   "templating": {
     "list": [
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "${datasource}",
-        "definition": "label_values(ccloud_metric_retained_bytes, kafka_id)",
-        "description": null,
-        "error": null,
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": true,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(ccloud_metric_retained_bytes, kafka_id)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
       {
         "allValue": "",
         "current": {},

--- a/templates/kafka-lag-exporter.json
+++ b/templates/kafka-lag-exporter.json
@@ -101,7 +101,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(50, kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(50, kafka_consumergroup_group_max_lag_seconds{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -187,7 +187,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(25, kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(25, kafka_consumergroup_group_lag_seconds{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -275,7 +275,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(50, kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(50, kafka_consumergroup_group_max_lag{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -361,7 +361,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(25, kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "topk(25, kafka_consumergroup_group_lag{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -476,7 +476,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
+          "expr": "kafka_consumergroup_group_max_lag_seconds{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -484,7 +484,7 @@
           "refId": "A"
         },
         {
-          "expr": "kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
+          "expr": "kafka_consumergroup_group_max_lag{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -601,7 +601,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}) by (group)",
+          "expr": "max(kafka_consumergroup_group_lag_seconds{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"}) by (group)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -609,7 +609,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+          "expr": "sum(kafka_consumergroup_group_offset{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -617,7 +617,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum((kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"} * 0)\n+ on(namespace,cluster_name,topic,partition) group_left() kafka_partition_latest_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\"})",
+          "expr": "sum((kafka_consumergroup_group_offset{cluster_name=\"${clusterName}\",group=~\"$consumer_group\"} * 0)\n+ on(namespace,cluster_name,topic,partition) group_left() kafka_partition_latest_offset{cluster_name=\"${clusterName}\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sum of latest offsets",
@@ -938,48 +938,6 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "${datasource}",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "query_result(kafka_consumergroup_group_lag)",
-        "refresh": 1,
-        "regex": "/.*namespace=\"([^\"]*).*/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "${datasource}",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Cluster Name",
-        "multi": false,
-        "name": "cluster_name",
-        "options": [],
-        "query": "query_result(kafka_consumergroup_group_lag{namespace=\"$namespace\"})",
-        "refresh": 1,
-        "regex": "/.*cluster_name=\"([^\"]*).*/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
         "allValue": ".*",
         "current": {},
         "datasource": "${datasource}",
@@ -989,7 +947,7 @@
         "multi": true,
         "name": "consumer_group",
         "options": [],
-        "query": "query_result(kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\"})",
+        "query": "query_result(kafka_consumergroup_group_lag{cluster_name=\"${clusterName}\"})",
         "refresh": 1,
         "regex": "/.*group=\"([^\"]*).*/",
         "skipUrlSync": false,


### PR DESCRIPTION
Adds ACL so kafka lag exporter service account can properly connect and read data
Removes variables from dashboards so each module creates dashboards for its own cluster only