### PR TITLE
Add Cluster ID and REST API endpoint to outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,11 @@ locals {
   bootstrap_servers = [
     replace(confluentcloud_kafka_cluster.cluster.bootstrap_servers, "SASL_SSL://", "")
   ]
+
+  # Since Mongey's Confluent provider doesn't provide rest endpoint url
+  # we should build it ourselves basing on the assumption that domain
+  # name is the same as in bootstrap_servers
+  rest_api_endpoint = replace(confluentcloud_kafka_cluster.cluster.bootstrap_servers, "/^SASL_SSL:\\/\\/(.*):([0-9]+)$/", "https://$1:443")
   service_accounts = distinct(
     concat(
       [for v in local.readers_map : v.user],

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,16 @@ output "kafka_url" {
   value       = local.bootstrap_servers
 }
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = confluentcloud_kafka_cluster.cluster.id
+}
+
+output "rest_api_endpoint" {
+  description = "REST API endpoint to manage the cluster"
+  value       = local.rest_api_endpoint
+}
+
 output "admin_api_key" {
   description = "Admin user api key and secret"
   value       = confluentcloud_api_key.admin_api_key


### PR DESCRIPTION
The new outputs may be useful to create KafkaRestClass resources for Confluent for Kubernetes operator and manage Kafka Topics using k8s resources.

Confluent Admin REST API docs: https://docs.confluent.io/operator/current/co-manage-rest-api.html