### PR TITLE
Make logging configurable and default to INFO.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## NOTE: This is deprecated and no longer being used on new projects.
+
+We're using this module now:
+
+https://github.com/dapperlabs-platform/terraform-confluent-official-kafka-cluster
+
 # Confluent Kafka cluster
 
 https://www.confluent.io/confluent-cloud/
@@ -62,28 +68,93 @@ The module outputs a map of service account credentials, keyed by the names prov
 
 ## Requirements
 
-- Terraform >= 1.0.0
-- Mongey/confluentcloud >= 0.0.12
-- Mongey/kafka >= 0.2.11
-- grafana/grafana >= 1.14.0
+| Name | Version |
+|------|---------|
+| <a name="requirement_confluentcloud"></a> [confluentcloud](#requirement\_confluentcloud) | >= 0.0.12 |
+| <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | ~> 1.20 |
+| <a name="requirement_kafka"></a> [kafka](#requirement\_kafka) | >= 0.2.11 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_confluentcloud"></a> [confluentcloud](#provider\_confluentcloud) | >= 0.0.12 |
+| <a name="provider_grafana"></a> [grafana](#provider\_grafana) | ~> 1.20 |
+| <a name="provider_kafka"></a> [kafka](#provider\_kafka) | >= 0.2.11 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [confluentcloud_api_key.admin_api_key](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/api_key) | resource |
+| [confluentcloud_api_key.ccloud_exporter_api_key](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/api_key) | resource |
+| [confluentcloud_api_key.kafka_lag_exporter_api_key](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/api_key) | resource |
+| [confluentcloud_api_key.service_account_api_keys](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/api_key) | resource |
+| [confluentcloud_environment.environment](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/environment) | resource |
+| [confluentcloud_kafka_cluster.cluster](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/kafka_cluster) | resource |
+| [confluentcloud_service_account.kafka_lag_exporter](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/service_account) | resource |
+| [confluentcloud_service_account.service_accounts](https://registry.terraform.io/providers/Mongey/confluentcloud/latest/docs/resources/service_account) | resource |
+| [grafana_dashboard.ccloud_exporter](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/dashboard) | resource |
+| [grafana_dashboard.kafka_lag_exporter](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/dashboard) | resource |
+| [grafana_folder.confluent_cloud](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/folder) | resource |
+| [kafka_acl.group_readers](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/acl) | resource |
+| [kafka_acl.kafka_lag_exporter_describe_consumer_group](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/acl) | resource |
+| [kafka_acl.kafka_lag_exporter_describe_topic](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/acl) | resource |
+| [kafka_acl.kafka_lag_exporter_read_topic](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/acl) | resource |
+| [kafka_acl.readers](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/acl) | resource |
+| [kafka_acl.writers](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/acl) | resource |
+| [kafka_topic.topics](https://registry.terraform.io/providers/Mongey/kafka/latest/docs/resources/topic) | resource |
+| [kubernetes_deployment.ccloud_exporter_deployment](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_deployment.lag_exporter_deployment](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_secret.ccloud_exporter_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.ccloud_exporter_config_file](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.lag_exporter_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_service_account.ccloud_exporter_service_account](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [kubernetes_service_account.lag_exporter_service_account](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [random_pet.pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-| Name                                                                                                                                                                                                                                    | Description                                                                                                  | Type   | Default | Required |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------ | ------- | :------: |
-| name                                                                                                                                                                                                                                    | Kafka cluster identifier. Will be prepended by the environment value in Confluent cloud                      | string |         |    x     |
-| environment                                                                                                                                                                                                                             | Application environment that uses the cluster                                                                | string |         |    x     |
-| gcp_region                                                                                                                                                                                                                              | GCP region in which to deploy the cluster. See https://docs.confluent.io/cloud/current/clusters/regions.html | string |         |    x     |
-| availability                                                                                                                                                                                                                            | Cluster availability. LOW or HIGH                                                                            | string | LOW     |          |
-| storage                                                                                                                                                                                                                                 | Storage limit(GB)                                                                                            | number | 5000    |          |
-| network_egress                                                                                                                                                                                                                          | Network egress limit(MBps)                                                                                   | number | 100     |          |
-| network_ingress                                                                                                                                                                                                                         | Network ingress limit(MBps)                                                                                  | number | 100     |          |
-| cluster_tier                                                                                                                                                                                                                            | Cluster tier                                                                                                 | string | BASIC   |          |
-| service_provider                                                                                                                                                                                                                        | Confluent cloud service provider. AWS, GCP, Azure                                                            | string | GCP     |          |
-| topics                                                                                                                                                                                                                                  | Kafka topic definitions.                                                                                     |
-| Object map keyed by topic name with topic configuration values as well as reader and writer ACL lists. Values provided to the ACL lists will become service accounts with { key, secret } objects output by service_account_credentials | list(object)                                                                                                 |        | x       |
-| enable_metric_exporters                                                                                                                                                                                                                 | Whether to deploy metrics exporters                                                                          | bool   |         |  false   |
-| metric_exporters_namespace                                                                                                                                                                                                              | K8S Namespace in which to deploy metrics exporters                                                           | string |         |   sre    |
-| kafka_lag_exporter_image_version                                                                                                                                                                                                        | Kafka lag exporter image version                                                                             | string |         |          |
-| create_grafana_dashboards                                                                                                                                                                                                               | Whether to create Grafana dashboards                                                                         | bool   |         |  false   |
-| grafana_datasource                                                                                                                                                                                                                      | Grafana datasource to use in dashboards                                                                      | string |         |   null   |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_add_service_account_suffix"></a> [add\_service\_account\_suffix](#input\_add\_service\_account\_suffix) | Add pet name suffix to service account names to avoid collision | `bool` | `false` | no |
+| <a name="input_availability"></a> [availability](#input\_availability) | Cluster availability. LOW or HIGH | `string` | `"LOW"` | no |
+| <a name="input_ccloud_exporter_annotations"></a> [ccloud\_exporter\_annotations](#input\_ccloud\_exporter\_annotations) | CCloud exporter annotations | `map(string)` | `{}` | no |
+| <a name="input_ccloud_exporter_container_resources"></a> [ccloud\_exporter\_container\_resources](#input\_ccloud\_exporter\_container\_resources) | Container resource limit configuration | `map(map(string))` | <pre>{<br>  "limits": {<br>    "cpu": "500m",<br>    "memory": "2Gi"<br>  },<br>  "requests": {<br>    "cpu": "250m",<br>    "memory": "1Gi"<br>  }<br>}</pre> | no |
+| <a name="input_ccloud_exporter_image_version"></a> [ccloud\_exporter\_image\_version](#input\_ccloud\_exporter\_image\_version) | Exporter Image Version | `string` | `"latest"` | no |
+| <a name="input_cku"></a> [cku](#input\_cku) | Number of CKUs | `number` | `null` | no |
+| <a name="input_cluster_tier"></a> [cluster\_tier](#input\_cluster\_tier) | Cluster tier | `string` | `"BASIC"` | no |
+| <a name="input_create_grafana_dashboards"></a> [create\_grafana\_dashboards](#input\_create\_grafana\_dashboards) | Whether to create grafana dashboards with default metric exporter panels | `bool` | `false` | no |
+| <a name="input_enable_metric_exporters"></a> [enable\_metric\_exporters](#input\_enable\_metric\_exporters) | Whether to deploy kafka-lag-exporter and ccloud-exporter in a kubernetes cluster | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Application environment that uses the cluster | `string` | n/a | yes |
+| <a name="input_exporters_node_selector"></a> [exporters\_node\_selector](#input\_exporters\_node\_selector) | K8S Deployment node selector for metric exporters | `map(string)` | `null` | no |
+| <a name="input_gcp_region"></a> [gcp\_region](#input\_gcp\_region) | GCP region in which to deploy the cluster. See https://docs.confluent.io/cloud/current/clusters/regions.html | `string` | n/a | yes |
+| <a name="input_grafana_datasource"></a> [grafana\_datasource](#input\_grafana\_datasource) | Name of Grafana data source where Kafka metrics are stored | `string` | `null` | no |
+| <a name="input_kafka_lag_exporter_annotations"></a> [kafka\_lag\_exporter\_annotations](#input\_kafka\_lag\_exporter\_annotations) | Lag exporter annotations | `map(string)` | `{}` | no |
+| <a name="input_kafka_lag_exporter_container_resources"></a> [kafka\_lag\_exporter\_container\_resources](#input\_kafka\_lag\_exporter\_container\_resources) | Container resource limit configuration | `map(map(string))` | <pre>{<br>  "limits": {<br>    "cpu": "500m",<br>    "memory": "2Gi"<br>  },<br>  "requests": {<br>    "cpu": "250m",<br>    "memory": "1Gi"<br>  }<br>}</pre> | no |
+| <a name="input_kafka_lag_exporter_image_version"></a> [kafka\_lag\_exporter\_image\_version](#input\_kafka\_lag\_exporter\_image\_version) | See https://github.com/seglo/kafka-lag-exporter/releases | `string` | n/a | yes |
+| <a name="input_kafka_lag_exporter_log_level"></a> [kafka\_lag\_exporter\_log\_level](#input\_kafka\_lag\_exporter\_log\_level) | Lag exporter log level | `string` | `"INFO"` | no |
+| <a name="input_metric_exporters_namespace"></a> [metric\_exporters\_namespace](#input\_metric\_exporters\_namespace) | Namespace to deploy exporters to | `string` | `"sre"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Kafka cluster identifier. Will be prepended by the environment value in Confluent cloud | `string` | n/a | yes |
+| <a name="input_network_egress"></a> [network\_egress](#input\_network\_egress) | Network egress limit(MBps) | `number` | `100` | no |
+| <a name="input_network_ingress"></a> [network\_ingress](#input\_network\_ingress) | Network ingress limit(MBps) | `number` | `100` | no |
+| <a name="input_service_provider"></a> [service\_provider](#input\_service\_provider) | Confluent cloud service provider. AWS, GCP, Azure | `string` | `"gcp"` | no |
+| <a name="input_storage"></a> [storage](#input\_storage) | Storage limit(GB) | `number` | `5000` | no |
+| <a name="input_topics"></a> [topics](#input\_topics) | Kafka topic definitions.<br>  Object map keyed by topic name with topic configuration values as well as reader and writer ACL lists.<br>  Values provided to the ACL lists will become service accounts with { key, secret } objects output by service\_account\_credentials | <pre>map(<br>    object({<br>      replication_factor = number<br>      partitions         = number<br>      config             = object({})<br>      acl_readers        = list(string)<br>      acl_writers        = list(string)<br>    })<br>  )</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_admin_api_key"></a> [admin\_api\_key](#output\_admin\_api\_key) | Admin user api key and secret |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | Cluster ID |
+| <a name="output_kafka_url"></a> [kafka\_url](#output\_kafka\_url) | URL to connect your Kafka clients to |
+| <a name="output_rest_api_endpoint"></a> [rest\_api\_endpoint](#output\_rest\_api\_endpoint) | REST API endpoint to manage the cluster |
+| <a name="output_service_account_credentials"></a> [service\_account\_credentials](#output\_service\_account\_credentials) | Map containing service account credentials.<br>  Keys are service account names provided to topics as readers and writers.<br>  Values are objects with key and secret values. |

--- a/kafka-lag-exporter.tf
+++ b/kafka-lag-exporter.tf
@@ -34,8 +34,12 @@ resource "kubernetes_secret" "lag_exporter_config" {
         namespace        = var.metric_exporters_namespace
         bootstrapBrokers = local.bootstrap_servers[0]
         clusterName      = local.lc_name
+        logLevel         = var.kafka_lag_exporter_log_level
     })
-    "logback.xml" = file("${path.module}/templates/logback.xml")
+    "logback.xml" = templatefile(
+      "${path.module}/templates/logback.xml", {
+        logLevel = var.kafka_lag_exporter_log_level
+    })
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ terraform {
     }
     grafana = {
       source  = "grafana/grafana"
-      version = ">= 1.14.0"
+      version = "~> 1.20"
     }
   }
 }

--- a/templates/application.conf
+++ b/templates/application.conf
@@ -36,6 +36,6 @@ kafka-lag-exporter {
 
   akka {
     loggers = ["akka.event.slf4j.Slf4jLogger"]
-    loglevel = "DEBUG"
+    loglevel = "${logLevel}"
     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   }

--- a/templates/logback.xml
+++ b/templates/logback.xml
@@ -1,15 +1,15 @@
 <configuration>
-    <variable name="ROOT_LOG_LEVEL" value="$${ROOT_LOG_LEVEL:-INFO}" />
-    <variable name="KAFKA_LAG_EXPORTER_LOG_LEVEL" value="$${KAFKA_LAG_EXPORTER_LOG_LEVEL:-INFO}" />
-    <variable name="KAFKA_LAG_EXPORTER_KAFKA_LOG_LEVEL" value="$${KAFKA_LAG_EXPORTER_KAFKA_LOG_LEVEL:-INFO}" />
+    <variable name="ROOT_LOG_LEVEL" value="${logLevel}" />
+    <variable name="KAFKA_LAG_EXPORTER_LOG_LEVEL" value="${logLevel}" />
+    <variable name="KAFKA_LAG_EXPORTER_KAFKA_LOG_LEVEL" value="${logLevel}" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date{ISO8601} %-5level %logger{36} %X{akkaSource} - %msg %ex%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.kafka" level="$${KAFKA_LAG_EXPORTER_KAFKA_LOG_LEVEL}"/>
-    <logger name="com.lightbend.kafkalagexporter" level="${KAFKA_LAG_EXPORTER_LOG_LEVEL}"/>
-    <root level="$${ROOT_LOG_LEVEL}">
+    <logger name="org.apache.kafka" level="${logLevel}"/>
+    <logger name="com.lightbend.kafkalagexporter" level="${logLevel}"/>
+    <root level="${logLevel}">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "kafka_lag_exporter_image_version" {
   type        = string
 }
 
+variable "kafka_lag_exporter_log_level" {
+  description = "Lag exporter log level"
+  type        = string
+  default     = "INFO"
+}
+
 variable "kafka_lag_exporter_container_resources" {
   description = "Container resource limit configuration"
   type        = map(map(string))


### PR DESCRIPTION
Based on the work done over here:

https://github.com/dapperlabs-platform/terraform-confluent-official-kafka-cluster/pull/26
https://github.com/dapperlabs-platform/terraform-confluent-official-kafka-cluster/pull/28

Porting this over so we can silence some logs on older clusters.

Also - adding a deprecation notice and pointing to the current module.